### PR TITLE
Add fixup pattern for attachment

### DIFF
--- a/kibela-fixup-imported-contents.ts
+++ b/kibela-fixup-imported-contents.ts
@@ -47,6 +47,9 @@ const newUrlPrefix = `https://${TEAM}.kibe.la`;
 // URLs are handled by the next secrion
 const mdLinkPattern = /\[[^\[]+\]\(([/\.][^\)]*)\)+/g;
 
+const attachmentSrcPattern = /src=["'](.*\/attachments\/.+?)["']/g;
+const attachmentMdPattern = /\[.*?\]\((.*\/attachments\/.+?)\)/g;
+
 type RelayId = unknown;
 
 type LogType = Readonly<{
@@ -137,6 +140,12 @@ function fixupContent(baseContent: string) {
     newContent = fixupContentWithMatchedResult(newContent, matched);
   }
   while ((matched = rawUrlPattern.exec(baseContent))) {
+    newContent = fixupContentWithMatchedResult(newContent, matched);
+  }
+  while ((matched = attachmentSrcPattern.exec(baseContent))) {
+    newContent = fixupContentWithMatchedResult(newContent, matched);
+  }
+  while ((matched = attachmentMdPattern.exec(baseContent))) {
     newContent = fixupContentWithMatchedResult(newContent, matched);
   }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">= 10"
   },
   "scripts": {
-    "test": "tsc --noEmit && ts-node kibela-import.ts --exported-from bitjourney test/fixtures/kibela-test-0.zip",
+    "test": "tsc && ts-node kibela-import.ts --exported-from bitjourney test/fixtures/kibela-test-0.zip",
     "ping": "ts-node kibela-ping.ts"
   },
   "keywords": [],


### PR DESCRIPTION
取り込み後に記事内で添付ファイルが表示されない問題を解消します。

`kibela-import.ts`で記事等の取り込みを行いログを出力し、そのログを読み込んで`kibela-fixup-imported-contents.ts`で記事内のリンクの置き換え(出力元で有効なリンクを取り込み先で有効なリンクに変換する)等をしています。
Kibela内の記事へのリンクの置き換えはされているのですが添付ファイルの置き換えがされない状態で
記事本文から添付ファイルのリンクを抽出する正規表現が足りていないようだったので追加しました。

---

### 動作確認

Kibela内の記事のリンク、画像の添付、PDFの添付のリンクが正しく表示されることを確認しています。
(ローカルで確認するには`kibela-fixup-imported-contents.ts`の`kibelaUrlExportedFrom`, `newUrlPrefix`を開発環境のものに変える必要があります)
`kibela-fixup-imported-contents.ts`実行時に記事の更新内容がdiff形式でコンソール出力されるので、以下に出力例を記載しておきます。

```
--- /notes/969
+++ /notes/969
@@ -1,15 +1,15 @@
-http://bitjourney.lvh.me:3000/notes/977
-http://bitjourney.lvh.me:3000/notes/975
+http://mtakada173-2.lvh.me:3000/notes/957
+http://mtakada173-2.lvh.me:3000/notes/955
Kibela内記事リンク

-<img title='kibesan.jpg' alt='kibesan' src='../attachments/5.jpg' width="260" data-meta='{"width":260,"height":260}'>
+<img title='kibesan.jpg' alt='kibesan' src='/attachments/5599b82a-7084-430d-b5bb-3c182a40eae2' width="260" data-meta='{"width":260,"height":260}'>
画像

-![Por3er-V2-Manual-v2.pdf](../attachments/8.pdf)
+![Por3er-V2-Manual-v2.pdf](/attachments/463048cf-87f1-4677-900c-1cbdecd5a4c5)
PDF
```
